### PR TITLE
symm_matrix: option to select set of bands

### DIFF
--- a/irrep/gvectors.py
+++ b/irrep/gvectors.py
@@ -388,7 +388,7 @@ def symm_eigenvalues(
 
 
 def symm_matrix(
-    K, RecLattice, WF, igall, A, S, T, spinor
+    K, RecLattice, WF, igall, A, S, T, spinor, bands=slice(None)
 ):
     """
     Computes the matrix S_mn = <Psi_m|{A|T}|Psi_n>
@@ -422,6 +422,9 @@ def symm_matrix(
         vectors of the unit cell.
     spinor : bool
         `True` if wave functions are spinors, `False` if they are scalars.
+    bands : slice, list or or 1D array
+        Calculates the matrix elements between bands listed here.
+        Default: all bands.
 
     Returns
     -------
@@ -432,6 +435,7 @@ def symm_matrix(
     npw1 = igall.shape[1]
     multZ = np.exp(-1.0j * (2 * np.pi * A.dot(T).dot(igall[:3, :] + K[:, None])))
     igrot = transformed_g(K, igall, RecLattice, A)
+    WF = WF[bands] # local copy if sliced, original (copy by reference) if not sliced
     if spinor:
         WF1 = np.stack([WF[:, igrot], WF[:, igrot + npw1]], axis=2).conj()
         WF2 = np.stack([WF[:, :npw1], WF[:, npw1:]], axis=2)


### PR DESCRIPTION
Added a new argument `bands=slice(None)` to the routine `symm_matrix(...)`, which informs which set of bands will be used in the matrix elements calculation.

The restriction to the selected bands is done at the line `WF = WF[bands]`, and the default value `bands=slice(None)` assure compatibility with previous versions.

Notice that if the code is called without a slice (default parameter), WF remains the original, while if a slice is chosen, a local reduced copy of WF is created. Therefore, the default `bands=slice(None)` also assures that no extra memory is used if the code is called without a slice.